### PR TITLE
Use the `Msg` object inside of `Bockly.Msg` to get the Block name

### DIFF
--- a/src/web/app.js
+++ b/src/web/app.js
@@ -1486,7 +1486,7 @@ BF2042Portal.Extensions = (function () {
         function getTranslation(key) {
             const splitKeys = key.split(".");
 
-            let firstElement = Blockly.Msg[splitKeys[0]];
+            let firstElement = Blockly.Msg.Msg[splitKeys[0]];
 
             for (let index = 1; index < splitKeys.Length; index++) {
                 firstElement = firstElement[splitKeys[index]];


### PR DESCRIPTION
With the latest update to portal, the `Blockly.Msg` is now a nested dict as follows
```js
Object { 
    Msg: {…}, 
    setLocale: Pa(t) 
}
```
So we need to use `Blockly.Msg.Msg`